### PR TITLE
Fix routing actions when there is no common subroute

### DIFF
--- a/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
+++ b/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
@@ -146,27 +146,27 @@ class Router<routerStateType: StateType> (var store: Store<routerStateType>,
             routeBuildingIndex -= 1
         }
 
+        // This is the 3. case:
+        // "The new route has a different element after the commonSubroute, we need to replace
+        //  the old route element with the new one"
+        if((oldRoute.count() > (commonSubroute + 1))
+                && (newRoute.count() > (commonSubroute + 1))) {
+            val changeAction = change(routableIndexForRouteSegment(commonSubroute),
+                    oldRoute[commonSubroute + 1],
+                    newRoute[commonSubroute + 1])
+
+            routingActions.add(changeAction)
+        }
         // This is the 1. case:
         // "The old route had an element after the commonSubroute and the new route does not
         //  we need to pop the route segment after the commonSubroute"
-        if(oldRoute.count() > newRoute.count()) {
+        else if(oldRoute.count() > newRoute.count()) {
             val popAction = pop(routableIndexForRouteSegment(routeBuildingIndex - 1),
                     oldRoute[routeBuildingIndex])
 
             //routingActions = routingActions.plus(popAction)
             routingActions.add(popAction)
             routeBuildingIndex -= 1
-        }
-        // This is the 3. case:
-        // "The new route has a different element after the commonSubroute, we need to replace
-        //  the old route element with the new one"
-        else if((oldRoute.count() > (commonSubroute + 1))
-                && (newRoute.count() > (commonSubroute + 1))) {
-            val changeAction = change(routableIndexForRouteSegment(commonSubroute),
-                    oldRoute[commonSubroute + 1],
-                    newRoute[commonSubroute + 1])
-
-           routingActions.add(changeAction)
         }
 
         // Push remainder of elements in new Route that weren't in old Route, this covers

--- a/rekotlin-router/src/test/java/org/rekotlinrouter/ReKotlinRouterUnitTests.kt
+++ b/rekotlin-router/src/test/java/org/rekotlinrouter/ReKotlinRouterUnitTests.kt
@@ -154,6 +154,43 @@ internal class ReKotlinRouterUnitTests {
     }
 
     @Test
+   // @DisplayName("generates a pop action followed by a change action on root when whole route changes")
+    fun test_change_action_on_root_when_no_common_subroute() {
+        // Given
+        val oldRoute = arrayListOf(mainActivityIdentifier,counterActivityIdentifier)
+        val newRoute = arrayListOf(statsActivityIdentifier)
+
+        // When
+        val routingActions = Router.routingActionsForTransitionFrom(oldRoute, newRoute)
+
+        // Then
+        var action1Correct: Boolean = false
+        var action2Correct: Boolean = false
+
+        routingActions.forEach { routingAction ->
+            when(routingAction) {
+                is pop -> {
+                    if(routingAction.responsibleRoutableIndex == 1
+                            && routingAction.segmentToBePopped == counterActivityIdentifier){
+                        action1Correct = true
+                    }
+                }
+                is change -> {
+                    if(routingAction.responsibleRoutableIndex == 0
+                            && routingAction.segmentToBeReplaced == mainActivityIdentifier
+                            && routingAction.newSegment == statsActivityIdentifier){
+                        action2Correct = true
+                    }
+                }
+            }
+        }
+
+        assertThat(action1Correct).isTrue()
+        assertThat(action2Correct).isTrue()
+        assertThat(routingActions.count()).isEqualTo(2)
+    }
+
+    @Test
    // @DisplayName("calculates no actions for transition from empty route to empty route")
     fun test_no_action_when_transistion_from_empty_to_empty_route(){
 


### PR DESCRIPTION
This PR fixes #5.

Previously, when changing route from [route1, route2] to [route3], it
would generate the following actions:
- pop route2
- pop route1
- push route3

This seemed inconsistent. Instead it should have produced the
following actions:
- pop route2
- change from route1 to route3

This is more in line with the behaviour when for example changing
routes from [route1] to [route2].

Note that the only change was to reorder the if/else blocks so that "case 3" is checked before "case 1". I also added a unit test.