### PR TITLE
Avoid using HashMap.replace()

### DIFF
--- a/rekotlin-router/build.gradle
+++ b/rekotlin-router/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
 
 
 group 'org.rekotlin-router'
-version '0.1.5'
+version '0.1.6'
 
 ext {
     junitPlugin_version = '1.0.0'

--- a/rekotlin-router/src/main/java/org/rekotlinrouter/NavigationReducer.kt
+++ b/rekotlin-router/src/main/java/org/rekotlinrouter/NavigationReducer.kt
@@ -43,11 +43,8 @@ class NavigationReducer {
         fun setRouteSpecificData(state: NavigationState, route: Route, data: Any): NavigationState {
             val routeString = FullRoute(route).routeString
 
-            if (state.routeSpecificState.containsKey(routeString)) {
-                state.routeSpecificState.replace(routeString, data)
-            } else {
-                state.routeSpecificState.put(routeString, data)
-            }
+            state.routeSpecificState[routeString] = data
+
             return state
         }
 


### PR DESCRIPTION
HashMap.replace() isn’t available on API levels below 26. The new code is also more idiomatic Kotlin.

This fixes #8.