### PR TITLE
refactor: change `Route` type from `ArrayList<>` to `List<>`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,4 +89,5 @@ install:
 
 script:
   - cp local.properties.ci local.properties
-  - "./gradlew assembleRelease bintrayUpload"
+  - ./gradlew check
+  - if [ TRAVIS_BRANCH == "master" ]; then ./gradlew assembleRelease bintrayUpload; fi

--- a/rekotlin-router/src/main/java/org/rekotlinrouter/Routable.kt
+++ b/rekotlin-router/src/main/java/org/rekotlinrouter/Routable.kt
@@ -3,7 +3,7 @@ package org.rekotlinrouter
 typealias RoutingCompletionHandler = () -> Unit
 
 typealias RouteElementIdentifier = String
-typealias Route = ArrayList<RouteElementIdentifier>
+typealias Route = List<RouteElementIdentifier>
 
 
 interface Routable {


### PR DESCRIPTION
the reasoning is (a) that this leaks the implementation detail into the
public API and (2) the the call site usage, e.g.
```
dispatch(SetRouteAction(arrayListOf("route-a", "route-b"))
// vs.
dispatch(SetRouteAction(listOf("route-a", "route-b"))
```

This does not break API contract, all code using the current version of
ReKotlin-router still compiles fine, because every instance of
`ArrayList` is also a `List`.