### PR TITLE
Rotation crash

### DIFF
--- a/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
+++ b/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
@@ -24,14 +24,15 @@ class Router<routerStateType : StateType>(var store: Store<routerStateType>,
     var lastNavigationState = NavigationState()
     // TODO: Collections.synchronizedList vs CopyOnWriteArrayList
     // var routables: List<Routable> = Collections.synchronizedList(arrayListOf<Routable>())
-    var routables: ArrayList<Routable> = arrayListOf()
+    val routables: ArrayList<Routable> = arrayListOf()
+
+    // ensure mainThreadHandler initialization before subscribing to the store
+    private val mainThreadHandler: Handler = Handler(Looper.getMainLooper())
 
     init {
         this.routables.add(rootRoutable)
         this.store.subscribe(this, stateTransform)
     }
-
-    private val mainThreadHandler = Handler(Looper.getMainLooper())
 
     override fun newState(state: NavigationState) {
         val routingActions = routingActionsForTransitionFrom(lastNavigationState.route, state.route)

--- a/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
+++ b/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt
@@ -38,13 +38,13 @@ class Router<routerStateType : StateType>(var store: Store<routerStateType>,
         val routingActions = routingActionsForTransitionFrom(lastNavigationState.route, state.route)
         if (routingActions.size > 0) {
             routingActions.forEach { routingAction ->
-                routingSerailActionHandler(routingAction, state)
+                routingSerialActionHandler(routingAction, state)
             }
             lastNavigationState = state.copy()
         }
     }
 
-    private fun routingSerailActionHandler(routingAction: RoutingAction, state: NavigationState) {
+    private fun routingSerialActionHandler(routingAction: RoutingAction, state: NavigationState) {
 
         synchronized(lock = routables) {
             when (routingAction) {


### PR DESCRIPTION
Fixes a crash that occurred when my activity was recreated due to device rotation.

A new router was created and subscribed to an existing store, with existing navigation substate, which immediately leads to a call to `routingSerialActionHandler` - which causes an NPE because `mainThreadHandler` was not initialized